### PR TITLE
Support external references using authorization configuration

### DIFF
--- a/packages/certification-service/README.md
+++ b/packages/certification-service/README.md
@@ -77,7 +77,13 @@ This folder contains the **API Scoring microservice** and its API. The structure
                 password: <GITHUB_PERSONAL_ACCESS_TOKEN>
       ```
 
-4. Once the process finishes, start the service:
+5.  Optionally, if you want to use references to external schemas with secured urls you can configure the authentication header:
+
+    - as environment variable:
+
+          CERWS_RESOLVER_AUTH_HEADER: Bearer your_token
+
+6. Once the process finishes, start the service:
 
  ```
  npm run start

--- a/packages/certification-service/code/config/custom-environment-variables.yaml
+++ b/packages/certification-service/code/config/custom-environment-variables.yaml
@@ -9,3 +9,6 @@ cerws:
         github-rest-client:
           username: CERWS_GH_USERNAME
           password: CERWS_GH_PASSWORD
+  spectral:
+    external-ref-resolver:
+      authorization-header: CERWS_RESOLVER_AUTH_HEADER

--- a/packages/certification-service/code/package-lock.json
+++ b/packages/certification-service/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inditextech/apicertification",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inditextech/apicertification",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -43,6 +43,7 @@
         "eslint-plugin-prettier": "5.1.3",
         "jest": "^29.7.0",
         "jest-sonar": "^0.2.16",
+        "nock": "^13.5.1",
         "nodemon": "3.0.3",
         "prettier": "3.2.4"
       }
@@ -5859,6 +5860,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -6414,6 +6421,20 @@
         "lodash.topath": "^4.5.2"
       }
     },
+    "node_modules/nock": {
+      "version": "13.5.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.1.tgz",
+      "integrity": "sha512-+s7b73fzj5KnxbKH4Oaqz07tQ8degcMilU4rrmnKvI//b0JMBU4wEXFQ8zqr+3+L4eWSfU3H/UoIVGUV0tue1Q==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -6955,6 +6976,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-from-env": {
@@ -13037,6 +13067,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -13466,6 +13502,17 @@
         "lodash.topath": "^4.5.2"
       }
     },
+    "nock": {
+      "version": "13.5.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.1.tgz",
+      "integrity": "sha512-+s7b73fzj5KnxbKH4Oaqz07tQ8degcMilU4rrmnKvI//b0JMBU4wEXFQ8zqr+3+L4eWSfU3H/UoIVGUV0tue1Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      }
+    },
     "node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -13848,6 +13895,12 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "proxy-from-env": {
       "version": "1.1.0",

--- a/packages/certification-service/code/package.json
+++ b/packages/certification-service/code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inditextech/apicertification",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "API scoring service",
   "author": "InditexTech Open Source Office",
   "license": "Apache-2.0",
@@ -63,9 +63,9 @@
     "koa-compose": "4.1.0",
     "koa2-swagger-ui": "5.10.0",
     "markdownlint": "^0.33.0",
+    "tar": "^6.2.0",
     "uuid": "9.0.1",
-    "winston": "3.11.0",
-    "tar": "^6.2.0"
+    "winston": "3.11.0"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
@@ -78,6 +78,7 @@
     "eslint-plugin-prettier": "5.1.3",
     "jest": "^29.7.0",
     "jest-sonar": "^0.2.16",
+    "nock": "^13.5.1",
     "nodemon": "3.0.3",
     "prettier": "3.2.4"
   },

--- a/packages/certification-service/code/src/evaluate/spectralEvaluate.js
+++ b/packages/certification-service/code/src/evaluate/spectralEvaluate.js
@@ -12,6 +12,7 @@ const { INFO_SEVERITY } = require("./severity");
 const { getAppLogger } = require("../log");
 const fs = require("fs");
 const path = require("path");
+const { createResolver } = require("./spectralExternalUrlResolver");
 
 const logger = getAppLogger();
 
@@ -55,7 +56,7 @@ const retrieveDocument = (filePath) => {
 };
 
 const evaluate = async (ruleset, apiSpecificationPath) => {
-  const spectral = new Spectral();
+  const spectral = new Spectral({ resolver: createResolver() });
 
   const fileExtension = path.extname(ruleset);
 

--- a/packages/certification-service/code/src/evaluate/spectralExternalUrlResolver.js
+++ b/packages/certification-service/code/src/evaluate/spectralExternalUrlResolver.js
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2024 Industria de Diseño Textil S.A. INDITEX
+//
+// SPDX-License-Identifier: Apache-2.0
+
+const { Resolver } = require("@stoplight/json-ref-resolver");
+const { resolveFile, createResolveHttp } = require("@stoplight/json-ref-readers");
+const { configValue } = require("../config/config");
+const { getAppLogger } = require("../log");
+const logger = getAppLogger();
+
+const resolveHttp = (resolverAuthHeader) => {
+  return createResolveHttp({
+    headers: {
+      Authorization: resolverAuthHeader,
+    },
+  });
+};
+
+const createResolver = () => {
+  const resolverAuthHeader = configValue("cerws.spectral.external-ref-resolver.authorization-header");
+  if (resolverAuthHeader) {
+    logger.info("Using custom http resolver");
+    const httpResolver = resolveHttp(resolverAuthHeader);
+    return new Resolver({
+      resolvers: {
+        https: { resolve: httpResolver },
+        http: { resolve: httpResolver },
+        file: { resolve: resolveFile },
+      },
+    });
+  }
+  return undefined;
+};
+
+module.exports = {
+  createResolver,
+};

--- a/packages/certification-service/code/src/verify/restLinter.js
+++ b/packages/certification-service/code/src/verify/restLinter.js
@@ -44,17 +44,15 @@ class RestLinter {
 const addFileNameToIssues = (issues, fileName, rootFolder, tempFolder) => {
   const TEMP_STRING = "temp";
   issues.forEach((issue) => {
-    if (issue.source && issue.source.startsWith("http")) {
-      issue.fileName = issue.source;
+    let sourceaux = issue.source;
+    issue.source = fileName;
+    if (sourceaux?.startsWith("http")) {
+      issue.fileName = sourceaux;
+    } else if (tempFolder) {
+      sourceaux = sourceaux ? sourceaux : tempFolder;
+      issue.fileName = sourceaux.substring(tempFolder.indexOf(TEMP_STRING) + TEMP_STRING.length);
     } else {
-      let sourceaux = issue.source;
-      issue.source = fileName;
-      if (tempFolder) {
-        sourceaux = sourceaux ? sourceaux : tempFolder;
-        issue.fileName = sourceaux.substring(tempFolder.indexOf(TEMP_STRING) + TEMP_STRING.length);
-      } else {
-        issue.fileName = cleanFileName(sourceaux, rootFolder);
-      }
+      issue.fileName = cleanFileName(sourceaux, rootFolder);
     }
   });
 };

--- a/packages/certification-service/code/src/verify/restLinter.js
+++ b/packages/certification-service/code/src/verify/restLinter.js
@@ -44,13 +44,17 @@ class RestLinter {
 const addFileNameToIssues = (issues, fileName, rootFolder, tempFolder) => {
   const TEMP_STRING = "temp";
   issues.forEach((issue) => {
-    let sourceaux = issue.source;
-    issue.source = fileName;
-    if (tempFolder) {
-      sourceaux = sourceaux ? sourceaux : tempFolder;
-      issue.fileName = sourceaux.substring(tempFolder.indexOf(TEMP_STRING) + TEMP_STRING.length);
+    if (issue.source && issue.source.startsWith("http")) {
+      issue.fileName = issue.source;
     } else {
-      issue.fileName = cleanFileName(sourceaux, rootFolder);
+      let sourceaux = issue.source;
+      issue.source = fileName;
+      if (tempFolder) {
+        sourceaux = sourceaux ? sourceaux : tempFolder;
+        issue.fileName = sourceaux.substring(tempFolder.indexOf(TEMP_STRING) + TEMP_STRING.length);
+      } else {
+        issue.fileName = cleanFileName(sourceaux, rootFolder);
+      }
     }
   });
 };

--- a/packages/certification-service/code/test/data/openapi-rest-external-refs.yml
+++ b/packages/certification-service/code/test/data/openapi-rest-external-refs.yml
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: 2024 Industria de Diseño Textil S.A. INDITEX
+#
+# SPDX-License-Identifier: Apache-2.0
+
+openapi: 3.0.0
+info:
+  title: API Example
+  version: "1.0.0"
+  contact:
+    name: Fake team
+    email: contact@email.fake
+  description: Sample description
+security:
+  - {}
+servers:
+  - url: https://myhost/v1
+tags:
+  - name: example
+paths:
+  /exampleendpoint:
+    get:
+      tags:
+        - example
+      summary: Example summary
+      description: Example description
+      operationId: exampleendpoint
+      responses:
+        "200":
+          description: Get example -
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Sample"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+        "504":
+          $ref: "#/components/responses/GatewayTimeout"
+components:
+  schemas:
+    Sample:
+      $ref: "https://shared-schemas/apis/common/sample/rest/sample.yml#/Sample"
+
+    ErrorDetail:
+      title: ErrorDetail
+      description: Error details
+      type: object
+      additionalProperties: false
+      properties:
+        status:
+          type: integer
+          description: HTTP status
+          format: int32
+          minimum: 100
+          maximum: 511
+          example: 400
+        title:
+          type: string
+          description: HTTP status text
+          example: "Bad request"
+          maxLength: 100
+        detail:
+          type: string
+          description: HTTP status detail
+          example: "Some field is not valid"
+          maxLength: 1000
+        code:
+          type: string
+          maxLength: 100
+          description: Error code
+          example: "INVALID_NAME"
+        description:
+          type: string
+          maxLength: 1000
+          description: Error description
+          example: Bad Request
+        level:
+          type: string
+          maxLength: 7
+          description: Error level
+          example: ERROR
+          enum:
+            - INFO
+            - ERROR
+            - WARNING
+            - FATAL
+        message:
+          type: string
+          maxLength: 10000
+          description: Error message (detailed description)
+          example:
+            Invalid Request. Please, check the data in the request (QueryString
+            Parameters and/or Body).
+      example:
+        code: "400"
+        description: Bad Request
+        level: ERROR
+        message:
+          Invalid Request. Please, check the data in the request (QueryString
+          Parameters and/or Body).
+
+    ErrorResponseBody:
+      title: ErrorResponseBody
+      description: Base model for error response body
+      type: object
+      additionalProperties: false
+      properties:
+        status:
+          type: integer
+          description: HTTP status
+          format: int32
+          minimum: 100
+          maximum: 511
+          example: 400
+        title:
+          type: string
+          description: HTTP status text
+          example: "Bad request"
+          maxLength: 100
+        detail:
+          type: string
+          description: HTTP status detail
+          example: "Some field is not valid"
+          maxLength: 1000
+        errors:
+          type: array
+          maxItems: 100
+          description: Details of each of the errors
+          items:
+            $ref: "#/components/schemas/ErrorDetail"
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponseBody"
+          example:
+            status: 400
+            title: Bad request
+            detail: Bad request
+            errors:
+              - code: "BAD_REQUEST"
+                description: Bad request
+                level: ERROR
+                message: Bad request, please check data sent in the request.
+
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponseBody"
+          example:
+            status: 401
+            title: Unauthorized
+            detail: Invalid credentials
+            errors:
+              - code: "UNAUTHORIZED"
+                description: Invalid credentials
+                level: ERROR
+                message: Invalid credentials provided
+
+    Forbidden:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponseBody"
+          example:
+            status: 403
+            title: Forbidden
+            detail: You have not access to this resource
+            errors:
+              - code: "FORBIDDEN"
+                description: Forbidden
+                level: ERROR
+                message: You have not access to this resource
+
+    NotFound:
+      description: Not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponseBody"
+          example:
+            status: 404
+            title: Not found
+            detail: The requested resource was not found
+            errors:
+              - code: "NOT_FOUND"
+                description: Not found
+                level: ERROR
+                message: The requested resource was not found
+
+    InternalError:
+      description: Internal error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponseBody"
+          example:
+            status: 500
+            title: Internal error
+            detail: There was a problem processing your request
+            errors:
+              - code: "INTERNAL_ERROR"
+                description: Internal error
+                level: ERROR
+                message: There was a problem processing your request
+
+    ServiceUnavailable:
+      description: Service Unavailable - Use it to report the Specific Errors
+        that the server suffers.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponseBody"
+          example:
+            status: 503
+            title: Service Unavailable
+            detail: Service Unavailable
+            errors:
+              - code: "SERVICE_UNAVAILABLE"
+                description: Service Unavailable
+                level: ERROR
+                message: There was a problem processing your request
+    GatewayTimeout:
+      description: Gateway Timeout
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponseBody"
+          example:
+            status: 504
+            title: Gateway Timeout
+            detail: Gateway Timeout
+            errors:
+              - code: "GATEWAY_TIMEOUT"
+                description: Gateway Timeout
+                level: ERROR
+                message: There was a problem processing your request

--- a/packages/certification-service/code/test/evaluate/spectralExternalUrlResolver.test.js
+++ b/packages/certification-service/code/test/evaluate/spectralExternalUrlResolver.test.js
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2024 Industria de Diseño Textil S.A. INDITEX
+//
+// SPDX-License-Identifier: Apache-2.0
+
+const { configValue } = require("../../src/config/config");
+const { createResolver } = require("../../src/evaluate/spectralExternalUrlResolver");
+jest.mock("../../src/config/config", () => {
+  const originalModule = jest.requireActual("../../src/config/config");
+  return {
+    __esModule: true,
+    ...originalModule,
+    configValue: jest.fn(),
+  };
+});
+
+describe("Spectral external url resolver", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("Should create resolver", () => {
+    configValue.mockReturnValue("Basic dXNlcjpwYXNz");
+
+    const resolver = createResolver();
+
+    expect(configValue).toHaveBeenCalledWith("cerws.spectral.external-ref-resolver.authorization-header");
+    expect(resolver).toBeDefined();
+    expect(Object.keys(resolver.resolvers)).toHaveLength(3);
+    expect(resolver.resolvers).toStrictEqual(
+      expect.objectContaining({
+        https: { resolve: expect.any(Function) },
+        http: { resolve: expect.any(Function) },
+        file: { resolve: expect.any(Function) },
+      }),
+    );
+  });
+
+  test("Create resolver should return undefined when no config", () => {
+    configValue.mockReturnValue(undefined);
+
+    const resolver = createResolver();
+
+    expect(configValue).toHaveBeenCalledWith("cerws.spectral.external-ref-resolver.authorization-header");
+    expect(resolver).toBeUndefined();
+  });
+});

--- a/packages/certification-service/code/test/verify/restLinter.test.js
+++ b/packages/certification-service/code/test/verify/restLinter.test.js
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2024 Industria de Diseño Textil S.A. INDITEX
+//
+// SPDX-License-Identifier: Apache-2.0
+
+const { VALIDATION_TYPE_DESIGN, VALIDATION_TYPE_SECURITY, API_PROTOCOL } = require("../../src/verify/types");
+const { RestLinter } = require("../../src/verify/restLinter");
+const linter = require("../../src/verify/lint");
+
+jest.mock("../../src/verify/lint");
+
+describe("Rest linter tests", () => {
+  test("Should add external url to issue filename", async () => {
+    const designIssues = [
+      {
+        code: "paths-param-examples",
+        message: '"sampleCode.example" must be defined',
+        path: ["components", "parameters", "pathSampleCode"],
+        severity: 1,
+        source: "/temp/my-api/rest/openapi-rest.yml",
+        range: {
+          start: {
+            line: 201,
+            character: 19,
+          },
+          end: {
+            line: 209,
+            character: 26,
+          },
+        },
+      },
+      {
+        code: "ensure-properties-examples",
+        message: "code doesn't have an example",
+        path: ["Sample", "properties", "code"],
+        severity: 1,
+        source: "https://shared-schemas/apis/common/sample/rest/sample.yml",
+        range: {
+          start: {
+            line: 5,
+            character: 9,
+          },
+          end: {
+            line: 6,
+            character: 18,
+          },
+        },
+      },
+    ];
+    const securityIssues = [
+      {
+        code: "global-security",
+        message: "Global 'security' field is not defined",
+        path: [],
+        severity: 0,
+        source: "/temp/my-api/rest/openapi-rest.yml",
+        range: {
+          start: {
+            line: 4,
+            character: 0,
+          },
+          end: {
+            line: 209,
+            character: 26,
+          },
+        },
+      },
+      {
+        code: "string-properties-required-max-length",
+        message: '"code.maxLength" property must be truthy',
+        path: ["Sample", "properties", "code"],
+        severity: 1,
+        source: "https://shared-schemas/apis/common/sample/rest/sample.yml",
+        range: {
+          start: {
+            line: 5,
+            character: 9,
+          },
+          end: {
+            line: 6,
+            character: 18,
+          },
+        },
+      },
+    ];
+    jest
+      .spyOn(linter, "lintFileWithSpectral")
+      .mockResolvedValueOnce(designIssues)
+      .mockResolvedValueOnce(securityIssues);
+    const apiValidation = {
+      validationDateTime: new Date().toISOString(),
+      apiName: "My API",
+      apiVersion: "1.0.0",
+      apiProtocol: API_PROTOCOL.REST,
+      result: [],
+      score: 0,
+      rating: "D",
+      ratingDescription: "",
+      hasErrors: false,
+    };
+
+    const design = {
+      designValidation: {
+        validationType: VALIDATION_TYPE_DESIGN,
+        spectralValidation: { issues: [] },
+        protolintValidation: { issues: [] },
+      },
+    };
+    const security = {
+      securityValidation: {
+        validationType: VALIDATION_TYPE_SECURITY,
+        spectralValidation: { issues: [] },
+        protolintValidation: { issues: [] },
+      },
+    };
+
+    await RestLinter.lintRest({
+      validationType: null,
+      file: "/temp/my-api/rest/openapi-rest.yml",
+      fileName: "my-api/rest/openapi-rest.yml",
+      rootFolder: "/root/folder",
+      apiValidation,
+      design,
+      security,
+      tempFolder: "/temp",
+    });
+
+    expect(design.designValidation.spectralValidation.issues).toHaveLength(designIssues.length);
+    expect(security.securityValidation.spectralValidation.issues).toHaveLength(securityIssues.length);
+    expect(design.designValidation.spectralValidation.issues).toStrictEqual(
+      expect.arrayContaining([
+        {
+          code: "paths-param-examples",
+          message: '"sampleCode.example" must be defined',
+          path: ["components", "parameters", "pathSampleCode"],
+          severity: 1,
+          source: "/my-api/rest/openapi-rest.yml",
+          range: {
+            start: {
+              line: 201,
+              character: 19,
+            },
+            end: {
+              line: 209,
+              character: 26,
+            },
+          },
+          fileName: "/my-api/rest/openapi-rest.yml",
+        },
+        {
+          code: "ensure-properties-examples",
+          message: "code doesn't have an example",
+          path: ["Sample", "properties", "code"],
+          severity: 1,
+          source: "https://shared-schemas/apis/common/sample/rest/sample.yml",
+          range: {
+            start: {
+              line: 5,
+              character: 9,
+            },
+            end: {
+              line: 6,
+              character: 18,
+            },
+          },
+          fileName: "https://shared-schemas/apis/common/sample/rest/sample.yml",
+        },
+      ]),
+    );
+    expect(security.securityValidation.spectralValidation.issues).toStrictEqual(
+      expect.arrayContaining([
+        {
+          code: "global-security",
+          message: "Global 'security' field is not defined",
+          path: [],
+          severity: 0,
+          source: "/my-api/rest/openapi-rest.yml",
+          range: {
+            start: {
+              line: 4,
+              character: 0,
+            },
+            end: {
+              line: 209,
+              character: 26,
+            },
+          },
+          fileName: "/my-api/rest/openapi-rest.yml",
+        },
+        {
+          code: "string-properties-required-max-length",
+          message: '"code.maxLength" property must be truthy',
+          path: ["Sample", "properties", "code"],
+          severity: 1,
+          source: "https://shared-schemas/apis/common/sample/rest/sample.yml",
+          range: {
+            start: {
+              line: 5,
+              character: 9,
+            },
+            end: {
+              line: 6,
+              character: 18,
+            },
+          },
+          fileName: "https://shared-schemas/apis/common/sample/rest/sample.yml",
+        },
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the score engine supports $ref within the same repository and external url references without authentication.

Issue Number:  #[14](https://github.com/InditexTech/api-scoring-engine/issues/14)

## What is the new behavior?

The purpose of this pull request is to add the possibility of supporting external references to private repositories, which require authentication. Adding a custom $ref resolver to Spectral to do so.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No, the configuration for authorization is optional. If it is not defined, the behavior will be the same as now

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This pull request introduces changes to handle external references to authenticated services.

It should be mentioned that to simulate authenticated services, the [nock](https://github.com/nock/nock) library is added. This library has an [MIT license](https://github.com/nock/nock?tab=MIT-1-ov-file#readme)

Affected paths:

[packages/certification-service/README.md](https://github.com/InditexTech/api-scoring-engine/pull/15/files#diff-40dc5289977785f784a23cf2d1e7bd9e4204a0e24b579b8e769f9e17c6d6ad4dR80):

- Added new point in the **How ​​to run the scoring service** section, explaining how to configure authentication to resolve external references to authenticated services.

[packages/certification-service/code/config/custom-environment-variables.yaml](https://github.com/InditexTech/api-scoring-engine/pull/15/files#diff-8762b43c09434ee020889d35c9642ac4dd7ccceb2ead97d9b5cefe8704eeb9c2R12):

- Added config to resolve environment variable with authorization header

[packages/certification-service/code/package.json](https://github.com/InditexTech/api-scoring-engine/pull/15/files#diff-7f36da9cef9c0c49a46c873ff699aadef71dea47d540cd318e3c13d4149fb189R81):

- Updated version to 1.1.0.
- Added `nock ^13.5.1` library as dev dependency.

[packages/certification-service/code/package-lock.json](https://github.com/InditexTech/api-scoring-engine/pull/15/files#diff-fa090bba613553bd098fc1999e79b148aeb50725081a6d58504c7f4c78d285b3L3):

- Added nock dependency and its dependencies

(new) [packages/certification-service/code/src/evaluate/spectralExternalUrlResolver.js](https://github.com/InditexTech/api-scoring-engine/pull/15/files#diff-1efc5ccf35066b678c28065674e5d2d1cdfb42cc23c64ee3f780dbe743c34726R5):

- Created new function to create a custom $ref resolver to add the authorization header and export it (`createResolver`). If the configuration is not defined (`cerws.spectral.external-ref-resolver.authorization-header`), the function will return undefined, and the behavior of spectral will be the same as before.

[packages/certification-service/code/src/evaluate/spectralEvaluate.js](https://github.com/InditexTech/api-scoring-engine/pull/15/files#diff-1efc5ccf35066b678c28065674e5d2d1cdfb42cc23c64ee3f780dbe743c34726R5):

- Imported the `createResolver` function from `spectralExternalUrlResolver`.
- Added the resolver to the Spectral constructor options. (`const spectral = new Spectral({ resolve: createResolver() });`)

[packages/certification-service/code/src/verify/restLinter.js](https://github.com/InditexTech/api-scoring-engine/pull/15/files#diff-eff1177413192d8e43cfbf8e101d3a27e9cf031b066a0c8e4bb6d68a8195f9d5R49):

- Updated the `addFileNameToIssues` function to take into account external $refs and return the url as the fileName of the issue

(new) [packages/certification-service/code/test/data/openapi-rest-external-refs.yml](https://github.com/InditexTech/api-scoring-engine/pull/15/files#diff-0838048c9903693a6681e90679fc05c79e5d5c1e98bb948f6aa9fcd314bde39dR5):

- Added example API with external references to be used in tests.

[packages/certification-service/code/test/evaluate/spectralEvaluate.test.js](https://github.com/InditexTech/api-scoring-engine/pull/15/files#diff-7dc8511f2b377b6e39f66fc14e5844b4dca76d6b1f99f30d672b670aec38c62eR94):

- Imported the `nock` library to mock external $ref calls, adding authorization.
- Mock the configuration module `src/config/config`. The default behavior of the `configvalue` function is to call the module without mocking.
- Fix in `expectedRESTResult` and `expectedRESTSecurityResult` the lines of the issue, because when adding the header with the license and copyright they are different.
- Added test to check the resolution of external references with authorization, using the `nock` library and mocking the configuration.

(new) [packages/certification-service/code/test/evaluate/spectralExternalUrlResolver.test.js](https://github.com/InditexTech/api-scoring-engine/pull/15/files#diff-bb149324dc5ea73b9f011eadc9a8eac5f6a06f56f1fd2b34e80079f33c35af57R16):

- Added test for creating the custom $ref resolver

(new) [packages/certification-service/code/test/verify/restLinter.test.js](https://github.com/InditexTech/api-scoring-engine/pull/15/files#diff-301fee1042aefcce21c00d35e80b51ea5feafb433a6cdb154f8c1a73a864a5d5R11):

- Added test to check that the `fileName` of the issue when it is a url.


Tests execution summary:
![tests-summary](https://github.com/InditexTech/api-scoring-engine/assets/112618196/a295cc23-d352-4150-b4db-c9e106d6be4c)

